### PR TITLE
Fix MDX rendering for edge by using ClientMDXContent

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 import { BiChevronLeft } from "react-icons/bi";
-import { MDXContent } from "@content-collections/mdx/react";
+import ClientMDXContent from "@/components/ClientMDXContent";
 import { formatDate } from "@/services/formatDate";
 import { metadataContent } from "@/services/metadata";
 import type { Metadata } from "next";
@@ -13,62 +13,66 @@ import ClientGiscus from "@/components/ClientGiscus";
 import { CustomTheme } from "@/components/CustomTheme";
 
 type DetailBlogProps = {
-	params: Promise<{
-		slug: string;
-	}>;
+  params: Promise<{
+    slug: string;
+  }>;
 };
 
 export async function generateMetadata({
-	params,
+  params,
 }: DetailBlogProps): Promise<Metadata> {
-	const slug = (await params).slug;
+  const slug = (await params).slug;
 
-	const detailBlogData = getBlogMetadataBySlug(slug);
+  const detailBlogData = getBlogMetadataBySlug(slug);
 
-	return metadataContent({
-		title: detailBlogData.title,
-		description: detailBlogData.summary,
-		slug: `blog/${slug}`,
-	});
+  return metadataContent({
+    title: detailBlogData.title,
+    description: detailBlogData.summary,
+    slug: `blog/${slug}`,
+  });
 }
 
 const SingeBlogPage = async ({ params }: DetailBlogProps) => {
-	const blogData = getBlogBySlug((await params).slug);
-	return (
-		<GeneralWrapper>
-			<section>
-				<Image
-					alt="cover"
-					src={blogData.coverImg}
-					width={500}
-					height={300}
-					className="aspect-video h-auto w-full rounded-lg object-fill"
-				/>
-				<h1>{blogData.title}</h1>
-				<div className="flex flex-wrap items-center justify-between gap-4">
-					<div className="flex items-center gap-4">
-						<h4 className="m-0">Published Date: {formatDate(blogData.date)}</h4>
-						<h5 className={clsx("badge badge-neutral shadow-sm")}>
-							{blogData.category}
-						</h5>
-					</div>
-					<ShareButtonFlex title={blogData.title} />
-				</div>
-			</section>
-			<hr className="mt-4" />
-			<section className="mt-6">
-				<MDXContent code={blogData.mdx} components={CustomTheme} />
-			</section>
-			<Link
-				href="/blog"
-				className="btn btn-neutral mt-8 flex w-full items-center rounded-lg"
-			>
-				<BiChevronLeft size={24} />
-				Back to Blog List Page
-			</Link>
-			<ClientGiscus />
-		</GeneralWrapper>
-	);
+  const blogData = getBlogBySlug((await params).slug);
+  return (
+    <GeneralWrapper>
+      <section>
+        <Image
+          alt="cover"
+          src={blogData.coverImg}
+          width={500}
+          height={300}
+          className="aspect-video h-auto w-full rounded-lg object-fill"
+        />
+        <h1>{blogData.title}</h1>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <h4 className="m-0">Published Date: {formatDate(blogData.date)}</h4>
+            <h5 className={clsx("badge badge-neutral shadow-sm")}>
+              {blogData.category}
+            </h5>
+          </div>
+          <ShareButtonFlex title={blogData.title} />
+        </div>
+      </section>
+      <hr className="mt-4" />
+      <section className="mt-6">
+        <ClientMDXContent
+          code={blogData.mdx}
+          components={CustomTheme}
+          placeholder={<p>Loading content...</p>}
+        />
+      </section>
+      <Link
+        href="/blog"
+        className="btn btn-neutral mt-8 flex w-full items-center rounded-lg"
+      >
+        <BiChevronLeft size={24} />
+        Back to Blog List Page
+      </Link>
+      <ClientGiscus />
+    </GeneralWrapper>
+  );
 };
 
 export default SingeBlogPage;

--- a/src/app/quick-notes/[slug]/page.tsx
+++ b/src/app/quick-notes/[slug]/page.tsx
@@ -4,64 +4,68 @@ import ShareButtonFlex from "@/components/ShareButtonFlex";
 import { metadataContent } from "@/services/metadata";
 import { getQuickNoteBySlug } from "@/services/quickNotes";
 
-import { MDXContent } from "@content-collections/mdx/react";
+import ClientMDXContent from "@/components/ClientMDXContent";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BiChevronLeft } from "react-icons/bi";
 
 type DetailQuickNoteProps = {
-	params: Promise<{
-		slug: string;
-	}>;
+  params: Promise<{
+    slug: string;
+  }>;
 };
 
 export async function generateMetadata({
-	params,
+  params,
 }: DetailQuickNoteProps): Promise<Metadata> {
-	const slug = (await params).slug;
+  const slug = (await params).slug;
 
-	const detailNoteData = getQuickNoteBySlug(slug);
+  const detailNoteData = getQuickNoteBySlug(slug);
 
-	return metadataContent({
-		title: `Quick Notes: ${detailNoteData.title}`,
-		description: detailNoteData.subtitle,
-		slug: `quick-notes/${slug}`,
-	});
+  return metadataContent({
+    title: `Quick Notes: ${detailNoteData.title}`,
+    description: detailNoteData.subtitle,
+    slug: `quick-notes/${slug}`,
+  });
 }
 
 const SingleNotePage = async ({
-	params,
+  params,
 }: {
-	params: Promise<{
-		slug: string;
-	}>;
+  params: Promise<{
+    slug: string;
+  }>;
 }) => {
-	const noteData = getQuickNoteBySlug((await params).slug);
-	return (
-		<GeneralWrapper>
-			<section className="flex flex-wrap items-end justify-between gap-4">
-				<div>
-					<h1>{noteData.title}</h1>
-					<h3>{noteData.subtitle}</h3>
-				</div>
-				<ShareButtonFlex title={noteData.title} />
-			</section>
+  const noteData = getQuickNoteBySlug((await params).slug);
+  return (
+    <GeneralWrapper>
+      <section className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1>{noteData.title}</h1>
+          <h3>{noteData.subtitle}</h3>
+        </div>
+        <ShareButtonFlex title={noteData.title} />
+      </section>
 
-			<hr />
+      <hr />
 
-			<section className="mt-8">
-				<MDXContent code={noteData.mdx} components={CustomTheme} />
-			</section>
+      <section className="mt-8">
+        <ClientMDXContent
+          code={noteData.mdx}
+          components={CustomTheme}
+          placeholder={<p>Loading content...</p>}
+        />
+      </section>
 
-			<Link
-				href="/quick-notes"
-				className="btn btn-neutral mt-8 w-full flex-items-center rounded-lg"
-			>
-				<BiChevronLeft size={24} />
-				Back to TIL Page
-			</Link>
-		</GeneralWrapper>
-	);
+      <Link
+        href="/quick-notes"
+        className="btn btn-neutral mt-8 w-full flex-items-center rounded-lg"
+      >
+        <BiChevronLeft size={24} />
+        Back to TIL Page
+      </Link>
+    </GeneralWrapper>
+  );
 };
 
 export default SingleNotePage;

--- a/src/components/ClientMDXContent.tsx
+++ b/src/components/ClientMDXContent.tsx
@@ -21,7 +21,7 @@
  * with this wrapper.)
  */
 
-import React, {
+import {
   useEffect,
   useState,
   type ReactNode,
@@ -118,7 +118,7 @@ export default function ClientMDXContent({
       throw error;
     }
     return (
-      <div className="rounded-md border border-error/30 bg-error/5 p-4 text-sm text-error">
+      <div className="rounded-md border border-error/30 bg-error/5 p-4 text-error text-sm">
         {errorFallback ? (
           errorFallback(error)
         ) : (

--- a/src/components/ClientMDXContent.tsx
+++ b/src/components/ClientMDXContent.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+/**
+ * ClientMDXContent
+ * -----------------
+ * Cloudflare Workers (and some other restricted runtimes) disallow dynamic code
+ * generation (eval / new Function). The server-side render path of
+ * @content-collections/mdx/react's <MDXContent /> may internally rely on that
+ * when hydrating compiled MDX, which triggers:
+ *
+ *   EvalError: Code generation from strings disallowed for this context
+ *
+ * To avoid that, we defer loading and rendering the MDX runtime completely to
+ * the browser by dynamically importing the renderer inside a useEffect. This
+ * ensures no evaluation happens during the server / edge execution phase.
+ *
+ * Usage:
+ *   <ClientMDXContent code={post.mdx} components={CustomTheme} />
+ *
+ * (Later, replace direct <MDXContent ... /> usages in server components / pages
+ * with this wrapper.)
+ */
+
+import React, {
+  useEffect,
+  useState,
+  type ReactNode,
+  type ComponentType,
+} from "react";
+
+/**
+ * Keep the runtime component props intentionally broad to avoid depending on the
+ * global JSX namespace (which triggered a build-time "Cannot find namespace 'JSX'" error
+ * in the constrained Cloudflare build setup).
+ */
+type MDXRuntimeComponent = ComponentType<{
+  code: unknown;
+  components?: Record<string, any>;
+}>;
+
+export interface ClientMDXContentProps {
+  code: unknown;
+  components?: Record<string, any>;
+  /**
+   * Optional placeholder (skeleton / spinner) while the client bundle for
+   * MDX runtime is loading.
+   */
+  placeholder?: ReactNode;
+  /**
+   * Render a simple error UI instead of throwing to the nearest error boundary.
+   * Default: false (rethrow so Next.js error boundary can catch).
+   */
+  inlineErrorFallback?: boolean;
+  /**
+   * Custom inline error fallback node (used only if inlineErrorFallback=true).
+   */
+  errorFallback?: (error: Error) => ReactNode;
+  className?: string;
+}
+
+/**
+ * A very small in-component cache so multiple instances on a single page
+ * don't each trigger a fresh dynamic import.
+ */
+let cachedMDXRuntime: MDXRuntimeComponent | null = null;
+let cachedError: Error | null = null;
+let pendingImport: Promise<void> | null = null;
+
+export default function ClientMDXContent({
+  code,
+  components,
+  placeholder = null,
+  inlineErrorFallback = true,
+  errorFallback,
+  className,
+}: ClientMDXContentProps) {
+  const [mdxComp, setMdxComp] = useState<MDXRuntimeComponent | null>(
+    () => cachedMDXRuntime,
+  );
+  const [error, setError] = useState<Error | null>(() => cachedError);
+
+  useEffect(() => {
+    if (cachedMDXRuntime || cachedError) {
+      // Already resolved (success or failure) from a previous instance.
+      return;
+    }
+
+    if (!pendingImport) {
+      pendingImport = import("@content-collections/mdx/react")
+        .then((mod) => {
+          cachedMDXRuntime = mod.MDXContent as MDXRuntimeComponent;
+          setMdxComp(() => cachedMDXRuntime);
+        })
+        .catch((err) => {
+          const e = err instanceof Error ? err : new Error(String(err));
+          cachedError = e;
+          setError(e);
+        })
+        .finally(() => {
+          pendingImport = null;
+        });
+    } else {
+      // Another instance is already importing; attach listeners through state update when resolved.
+      pendingImport
+        .then(() => {
+          if (cachedMDXRuntime) setMdxComp(() => cachedMDXRuntime);
+          if (cachedError) setError(cachedError);
+        })
+        .catch(() => {
+          // Error already captured in the primary promise.
+        });
+    }
+  }, []);
+
+  // Error handling
+  if (error) {
+    if (!inlineErrorFallback) {
+      throw error;
+    }
+    return (
+      <div className="rounded-md border border-error/30 bg-error/5 p-4 text-sm text-error">
+        {errorFallback ? (
+          errorFallback(error)
+        ) : (
+          <>
+            <strong>MDX render error:</strong>{" "}
+            <code className="break-all">{error.message}</code>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // Still loading runtime
+  if (!mdxComp) {
+    return placeholder ? <>{placeholder}</> : null;
+  }
+
+  const Runtime = mdxComp;
+
+  return (
+    <div className={className}>
+      <Runtime code={code} components={components} />
+    </div>
+  );
+}

--- a/src/components/CustomTheme.tsx
+++ b/src/components/CustomTheme.tsx
@@ -1,41 +1,42 @@
+"use client";
 import type {
-	AnchorHTMLAttributes,
-	DetailedHTMLProps,
-	HTMLAttributes,
-	ImgHTMLAttributes,
+  AnchorHTMLAttributes,
+  DetailedHTMLProps,
+  HTMLAttributes,
+  ImgHTMLAttributes,
 } from "react";
 import SyntaxComponent from "./SyntaxComponent";
 import ImageWithLightbox from "./ImageWithLightbox";
 
 export const CustomTheme = {
-	a: ({
-		href,
-		children,
-	}: DetailedHTMLProps<
-		AnchorHTMLAttributes<HTMLAnchorElement>,
-		HTMLAnchorElement
-	>) => (
-		<a
-			href={href}
-			className="link break-words hover:decoration-dashed hover:underline-offset-2"
-			target={String(href).startsWith("http") ? "_blank" : "_self"}
-			rel="noreferrer"
-		>
-			{children}
-		</a>
-	),
-	img: ({
-		src,
-		alt,
-	}: DetailedHTMLProps<
-		ImgHTMLAttributes<HTMLImageElement>,
-		HTMLImageElement
-	>) => <ImageWithLightbox src={src as string} alt={alt as string} />,
+  a: ({
+    href,
+    children,
+  }: DetailedHTMLProps<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    HTMLAnchorElement
+  >) => (
+    <a
+      href={href}
+      className="link break-words hover:decoration-dashed hover:underline-offset-2"
+      target={String(href).startsWith("http") ? "_blank" : "_self"}
+      rel="noreferrer"
+    >
+      {children}
+    </a>
+  ),
+  img: ({
+    src,
+    alt,
+  }: DetailedHTMLProps<
+    ImgHTMLAttributes<HTMLImageElement>,
+    HTMLImageElement
+  >) => <ImageWithLightbox src={src as string} alt={alt as string} />,
 
-	code: (
-		props: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>,
-	) => <SyntaxComponent props={props} />,
-	pre: (
-		props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>,
-	) => <pre className="bg-transparent p-0">{props.children}</pre>,
+  code: (
+    props: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>,
+  ) => <SyntaxComponent props={props} />,
+  pre: (
+    props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>,
+  ) => <pre className="bg-transparent p-0">{props.children}</pre>,
 };


### PR DESCRIPTION
Replace server-side MDXContent with a client-only wrapper to avoid dynamic code generation errors in restricted runtimes like Cloudflare Workers. Add ClientMDXContent component and update usages in blog and quick-notes pages.

# Description

# Linked Issues

# Preview or Screenshot
